### PR TITLE
Update GoogleAds-IMA-tvOS-SDK to version 4.15.1

### DIFF
--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
       Pod::UI.puts "RNVideo: enable IMA SDK"
 
       ss.ios.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.22.1'
-      ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.2'
+      ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.15.1'
       ss.pod_target_xcconfig = {
         'OTHER_SWIFT_FLAGS' => '$(inherited) -D USE_GOOGLE_IMA'
       }


### PR DESCRIPTION

## Summary
update dependency GoogleAds-IMA-tvOS-SDK from 4.2 to 4.15.1

### Motivation
get the latest bug fix updates

### Changes
      ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.2'
      to
      ss.tvos.dependency 'GoogleAds-IMA-tvOS-SDK', '~> 4.15.1'
