### PR TITLE
Extend availability check to tvOS 15.0 for audiovisualBackgroundPlaybackPolicy support

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -574,7 +574,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
             _player!.replaceCurrentItem(with: playerItem)
 
-            if #available(iOS 15.0, *) {
+            if #available(iOS 15.0,tvOS 15.0, *) {
                 if _playInBackground {
                     _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
                 } else {
@@ -601,7 +601,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             #endif
 
-            if #available(iOS 15.0, *) {
+            if #available(iOS 15.0,tvOS 15.0, *) {
                 if _playInBackground {
                     _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
                 } else {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -574,7 +574,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
             _player!.replaceCurrentItem(with: playerItem)
 
-            if #available(iOS 15.0,tvOS 15.0, *) {
+            if #available(iOS 15.0, tvOS 15.0, *) {
                 if _playInBackground {
                     _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
                 } else {
@@ -601,7 +601,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 }
             #endif
 
-            if #available(iOS 15.0,tvOS 15.0, *) {
+            if #available(iOS 15.0, tvOS 15.0, *) {
                 if _playInBackground {
                     _player!.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
                 } else {


### PR DESCRIPTION
## Summary
This PR updates the background playback behavior to support tvOS 15+, ensuring consistent functionality across iOS and tvOS when _playInBackground is enabled.

### Motivation
I wanted to make sure background playback works properly on tvOS as well as iOS.

### Changes
Updated the availability check from #available(iOS 15.0, *) to #available(iOS 15.0, tvOS 15.0, *)

## Test plan